### PR TITLE
Fix 441000 Hz to 44100 Hz typo

### DIFF
--- a/docs/source/notebooks/tutorial.ipynb
+++ b/docs/source/notebooks/tutorial.ipynb
@@ -22,7 +22,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In your conda environment, to extract embeddings according to the ISMIR paper, simply call `aisfx.inference.main()` on a directory consisting of only audio-files. No other function needs to be called. Input audio pre-processing will already be done for you, i.e., down-mix to 1 channel, normalize, re-sample to 44100.0kHz."
+    "In your conda environment, to extract embeddings according to the ISMIR paper, simply call `aisfx.inference.main()` on a directory consisting of only audio-files. No other function needs to be called. Input audio pre-processing will already be done for you, i.e., down-mix to 1 channel, normalize, re-sample to 44100 Hz."
    ]
   },
   {


### PR DESCRIPTION
Guessing this was probably a typo in the tutorial notebook (or there are now sound cards with _really_ high sample rates so we can make some nice music for dogs 🐶 😄 ).